### PR TITLE
Updates to tippecanoe tile generation

### DIFF
--- a/geo_dataproc/dataproc.sh
+++ b/geo_dataproc/dataproc.sh
@@ -27,11 +27,15 @@ fi
 # Ref: https://fuzzytolerance.info/blog/2017/02/02/Making-your-own-tiles-with-Tippecanoe/
 # Ref: https://wiki.openstreetmap.org/wiki/Zoom_levels
 tippecanoe -L $2:./data/layers/$2.geojson \
-    -f -F -ps -pf -pk -pt -Bg \
-    --drop-densest-as-needed \
-    -o ./data/layers/$2.mbtiles -z18 -Z10\
-    --drop-lines\
-    --force
+    --force \
+    --reverse \
+    -z16 -Z1 \
+    --extend-zooms-if-still-dropping \
+    --no-tile-size-limit \
+    --no-line-simplification \
+    --no-tiny-polygon-reduction \
+    --exclude-all \
+    -o ./data/layers/$2.mbtiles
 
 # Cleanup: save a bit of space in the container
 rm -rf /data/layers/$2 /data/layers/$2.geojson


### PR DESCRIPTION
Update to Tippecanoe tile generation options in dataproc.sh. Result is reduction of size of  mbtiles from ~85MB to ~10MB  and faster (10x?) generation time without losing much detail.

- Tile generation limited to zoom level 16
- Remove tile metadata (i.e. fields not used to draw shape)
- Reverse objects, tighter tile compression when serving to browser
